### PR TITLE
[Design] LinkButton Component 추가 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Signup from './pages/Signup/Signup';
 import AccountRecovery from './pages/AccountRecovery/AccountRecovery';
 import Upload from './pages/Upload/Upload';
 import TagSearch from './pages/Search/Search';
+import ErrorPage from './pages/ErrorPage/ErrorPage';
 
 function App() {
   const router = createBrowserRouter([
@@ -26,6 +27,10 @@ function App() {
         {
           path: '/tags',
           element: <TagSearch />,
+        },
+        {
+          path: '/*',
+          element: <ErrorPage />,
         },
       ],
     },

--- a/client/src/components/common/Button/Button.style.tsx
+++ b/client/src/components/common/Button/Button.style.tsx
@@ -1,12 +1,12 @@
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-interface ButtonProps {
+interface ButtonStyleProps {
   variant: 'primary' | 'point';
   shape: 'default' | 'round';
   size: 'small' | 'medium' | 'large' | 'XLarge' | 'XXLarge';
   fullWidth: boolean;
   disabled: boolean;
-  children: React.ReactNode;
 }
 const variantCSS = {
   point: css`
@@ -55,7 +55,6 @@ const sizeCSS = {
     font-size: var(--font-size-sm);
   `,
   large: css`
-    /* padding: 10px 10px; */
     padding: 10px 22px;
     font-size: var(--font-size-sm);
     margin: 15px 0;
@@ -66,13 +65,23 @@ const sizeCSS = {
     background-color: var(--color-primary-gray30);
   `,
   XXLarge: css`
-    /* padding: 10px 10px; */
     padding: 10px;
     font-size: var(--font-size-m);
   `,
 };
 
-export const S_ButtonBox = styled.button<ButtonProps>`
+export const S_LinkButton = styled(Link)<ButtonStyleProps>`
+  ${({ variant }) => variantCSS[variant]}
+  ${({ size }) => sizeCSS[size]}
+  ${({ shape }) => shapeCSS[shape]}
+  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  border: none;
+  transition: all 0.3s ease 0s;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+`;
+
+export const S_Button = styled.button<ButtonStyleProps>`
   ${({ variant }) => variantCSS[variant]}
   ${({ size }) => sizeCSS[size]}
   ${({ shape }) => shapeCSS[shape]}

--- a/client/src/components/common/Button/Button.tsx
+++ b/client/src/components/common/Button/Button.tsx
@@ -1,5 +1,5 @@
-import React, { Children } from 'react';
-import { S_ButtonBox } from './Button.style';
+import React from 'react';
+import { S_Button } from './Button.style';
 
 interface ButtonProps {
   variant: 'primary' | 'point';
@@ -8,7 +8,7 @@ interface ButtonProps {
   disabled?: boolean;
   fullWidth?: boolean;
   children: React.ReactNode;
-  buttonClickEvent?: () => void;
+  clickEventHandler?: () => void;
 }
 
 function Button({
@@ -17,20 +17,20 @@ function Button({
   size,
   disabled = false,
   fullWidth = false,
-  buttonClickEvent,
+  clickEventHandler,
   children,
 }: ButtonProps) {
   return (
-    <S_ButtonBox
+    <S_Button
       variant={variant}
       shape={shape}
       size={size}
       fullWidth={fullWidth}
       disabled={disabled}
-      onClick={buttonClickEvent}
+      onClick={clickEventHandler}
     >
       {children}
-    </S_ButtonBox>
+    </S_Button>
   );
 }
 

--- a/client/src/components/common/Button/LinkButton.tsx
+++ b/client/src/components/common/Button/LinkButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { S_LinkButton } from './Button.style';
+
+interface LinkButtonProps {
+  variant: 'primary' | 'point';
+  shape: 'default' | 'round';
+  size: 'small' | 'medium' | 'large';
+  disabled?: boolean;
+  fullWidth?: boolean;
+  children: React.ReactNode;
+  url: string;
+}
+
+function LinkButton({
+  variant,
+  shape,
+  size,
+  disabled = false,
+  fullWidth = false,
+  children,
+  url,
+}: LinkButtonProps) {
+  return (
+    <S_LinkButton
+      variant={variant}
+      shape={shape}
+      size={size}
+      fullWidth={fullWidth}
+      disabled={disabled}
+      to={url}
+    >
+      {children}
+    </S_LinkButton>
+  );
+}
+
+export default LinkButton;

--- a/client/src/pages/ErrorPage/ErrorPage.style.tsx
+++ b/client/src/pages/ErrorPage/ErrorPage.style.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import { ColFlex, RowFlex } from '../../styles/GlobalStyles';
+import BackgroundImage from '../../assets/imgs/image5.jpg';
+
+export const S_ErrorPageWrap = styled.main`
+  width: 100%;
+  height: calc(100vh - 70px); /* 100vh - 헤더크기 */
+  position: absolute;
+  background: url(${BackgroundImage}) no-repeat;
+  background-size: cover;
+  ${RowFlex}
+  align-items: center;
+`;
+
+export const S_ErrorPageContainer = styled.div`
+  background-color: rgba(255, 255, 255, 0.931);
+  border-radius: var(--box-radius-10);
+  text-align: center;
+  width: 640px;
+  height: 385px;
+  padding: 20px 50px;
+  box-sizing: border-box;
+`;
+
+export const S_ErrorBox = styled.div`
+  ${ColFlex}
+  width: 100%;
+  height: 100%;
+`;
+
+export const S_TextContainer = styled.div`
+  margin-bottom: 50px;
+`;
+
+export const S_ErrorTitleH1 = styled.h1`
+  color: var(--color-primary-green);
+  font-size: 6rem;
+`;
+
+export const S_ErrorSubTitleBold = styled.strong`
+  color: var(--color-primary-black);
+  font-size: var(--font-size-l);
+`;
+
+export const S_ErrorSubTitleP = styled.p`
+  color: var(--color-primary-black);
+  margin-top: 10px;
+`;
+
+export const S_ButtonContainer = styled.div`
+  ${ColFlex}
+  align-items: center;
+  margin-bottom: 25px;
+
+  > a {
+    padding: 10px 40px;
+  }
+`;

--- a/client/src/pages/ErrorPage/ErrorPage.tsx
+++ b/client/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,36 @@
+import LinkButton from '../../components/common/Button/LinkButton';
+import {
+  S_ButtonContainer,
+  S_ErrorBox,
+  S_ErrorPageContainer,
+  S_ErrorPageWrap,
+  S_ErrorSubTitleBold,
+  S_ErrorSubTitleP,
+  S_ErrorTitleH1,
+  S_TextContainer,
+} from './ErrorPage.style';
+
+function ErrorPage() {
+  return (
+    <S_ErrorPageWrap>
+      <S_ErrorPageContainer>
+        <S_ErrorBox>
+          <S_TextContainer>
+            <S_ErrorTitleH1>404</S_ErrorTitleH1>
+            <S_ErrorSubTitleBold>Page Not Found</S_ErrorSubTitleBold>
+            <S_ErrorSubTitleP>
+              The page you're looking for does not seem to exist
+            </S_ErrorSubTitleP>
+          </S_TextContainer>
+          <S_ButtonContainer>
+            <LinkButton variant="point" shape="default" size="large" url="/">
+              Go to Home
+            </LinkButton>
+          </S_ButtonContainer>
+        </S_ErrorBox>
+      </S_ErrorPageContainer>
+    </S_ErrorPageWrap>
+  );
+}
+
+export default ErrorPage;


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #42

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- LinkButton Component 추가 구현
## 🔥 변경 로직(optional)
<!-- 변경된 로직이 있다면 적어주세요. -->
```js
src/components/commom/Button/LinkButton.tsx

import React from 'react';
import { S_LinkButton } from './Button.style';

interface LinkButtonProps {
  variant: 'primary' | 'point';
  shape: 'default' | 'round';
  size: 'small' | 'medium' | 'large';
  disabled?: boolean;
  fullWidth?: boolean;
  children: React.ReactNode;
  url: string;
}

function LinkButton({
  variant,
  shape,
  size,
  disabled = false,
  fullWidth = false,
  children,
  url,
}: LinkButtonProps) {
  return (
    <S_LinkButton
      variant={variant}
      shape={shape}
      size={size}
      fullWidth={fullWidth}
      disabled={disabled}
      to={url}
    >
      {children}
    </S_LinkButton>
  );
}

export default LinkButton;
```

### 👓 고민사항(optional)
```
 <Button variant="point" shape="default" size="large"">
   <Link to="/">
     Go to Home
   </Link>
</Button>
```
버튼 클릭 시 페이지 이동을 위해  Link 태그를 추가했지만,  버튼 영역이 아닌  Go to Home 글씨 영역을 정확하게 클릭해야만 페이지가 이동 되는  문제가 있습니다.

이 문제를 해결하기 위해 Link요소로 된 버튼을 하나 더 추가했습니다.

기존의 Button styled componet

```
export const S_Button = styled.button<ButtonProps>``;
```

새로 추가한 LinkButton styled componet

```
export const S_Button = styled(Link)<ButtonProps>``;
```

### 📩 전달사항(optional)

버튼 클릭 시  페이지 이동이 되지 않는다면, 기존에 사용해왔던 Button 컴포넌트를 사용하시고
버튼 클릭 시 페이지 이동이 있는 경우에는  LinkButton 컴포넌트를 사용하시면 됩니다.

단,   LinkButton을 사용한다면 사용하는 곳에서 props로 이동할 url을 필수로 보내주셔야 합니다!

LinkButton 사용 예시
```js
<LinkButton variant="point" shape="default" size="large" url="/">
 Go to Home
</LinkButton>
```

