### PR TITLE
[Feature] Login 기능 개발 + Redux 생성

### DIFF
--- a/client/src/api/Login.ts
+++ b/client/src/api/Login.ts
@@ -12,17 +12,33 @@ export type ErrorResponse = {
   violationErrors: any[] | null;
   httpStatus: number | null;
   message: string | null;
+  authorization?: string;
 };
 
-const postLogin = async (loginForm: LoginValue) => {
+const postLogin = async (loginForm: LoginValue, keepLoggedIn: boolean) => {
   try {
-    await axios.post<undefined, AxiosResponse<ErrorResponse>>(
+    const response = await axios.post<undefined, AxiosResponse<ErrorResponse>>(
       `${import.meta.env.VITE_APP_API_URL}/api/auth/login`,
       {
         email: loginForm.email,
         password: loginForm.password,
       },
     );
+    const accessToken: string | undefined =
+      response.headers.authorization.replace(/^Bearer /, '');
+
+    if (keepLoggedIn) {
+      if (accessToken) {
+        const expirationTime = new Date().getTime() + 5 * 60 * 60 * 1000;
+        localStorage.setItem(
+          'accessToken',
+          JSON.stringify({
+            token: accessToken,
+            expiresAt: expirationTime,
+          }),
+        );
+      }
+    }
     window.history.back();
   } catch (error: unknown) {
     if (error instanceof AxiosError) {

--- a/client/src/api/Login.ts
+++ b/client/src/api/Login.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosResponse, AxiosError } from 'axios';
+import { LoginValue } from '../pages/Login/Login';
+
+export type FieldError = {
+  field: string;
+  rejectedValue: string;
+  message: string;
+};
+
+export type ErrorResponse = {
+  fieldErrors: FieldError[] | null;
+  violationErrors: any[] | null;
+  httpStatus: number | null;
+  message: string | null;
+};
+
+const postLogin = async (loginForm: LoginValue) => {
+  try {
+    await axios.post<undefined, AxiosResponse<ErrorResponse>>(
+      `${import.meta.env.VITE_APP_API_URL}/api/auth/login`,
+      {
+        email: loginForm.email,
+        password: loginForm.password,
+      },
+    );
+    window.history.back();
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        const errorResponse: ErrorResponse = error.response.data.message;
+        alert(errorResponse);
+      }
+    }
+  }
+};
+
+export default postLogin;

--- a/client/src/api/Login.ts
+++ b/client/src/api/Login.ts
@@ -15,7 +15,10 @@ export type ErrorResponse = {
   authorization?: string;
 };
 
-const postLogin = async (loginForm: LoginValue, keepLoggedIn: boolean) => {
+export const postLogin = async (
+  loginForm: LoginValue,
+  keepLoggedIn: boolean,
+) => {
   try {
     const response = await axios.post<undefined, AxiosResponse<ErrorResponse>>(
       `${import.meta.env.VITE_APP_API_URL}/api/auth/login`,
@@ -49,5 +52,3 @@ const postLogin = async (loginForm: LoginValue, keepLoggedIn: boolean) => {
     }
   }
 };
-
-export default postLogin;

--- a/client/src/api/Signup.ts
+++ b/client/src/api/Signup.ts
@@ -28,9 +28,14 @@ const postSignup = async (loginForm: LoginValue) => {
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       if (error.response) {
-        console.log(error.response);
-        const errorResponse: ErrorResponse = error.response.data;
-        alert(errorResponse.message);
+        const errorResponse: ErrorResponse = error.response.data.message;
+        if (errorResponse) {
+          alert(errorResponse);
+        } else {
+          const newErrorResponse: ErrorResponse =
+            error.response.data.fieldErrors[0].message;
+          alert(newErrorResponse);
+        }
       }
     }
   }

--- a/client/src/api/Signup.ts
+++ b/client/src/api/Signup.ts
@@ -1,18 +1,6 @@
 import axios, { AxiosResponse, AxiosError } from 'axios';
 import { LoginValue } from '../pages/Login/Login';
-
-type FieldError = {
-  field: string;
-  rejectedValue: string;
-  message: string;
-};
-
-type ErrorResponse = {
-  fieldErrors: FieldError[] | null;
-  violationErrors: any[] | null;
-  httpStatus: number | null;
-  message: string | null;
-};
+import { ErrorResponse } from './Login';
 
 const postSignup = async (loginForm: LoginValue) => {
   try {

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,0 +1,29 @@
+export const checkAuth = async () => {
+  const tokenString = localStorage.getItem('accessToken');
+  if (!tokenString) {
+    return false;
+  }
+
+  const { token, expiresAt } = JSON.parse(tokenString);
+
+  // 토큰이 만료된 경우
+  if (new Date().getTime() > expiresAt) {
+    localStorage.removeItem('accessToken');
+    /*
+    다시 발급받을 때 수정될 코드
+    try {
+      const response = await axios.get(`${import.meta.env.VITE_APP_API_URL}/api/auth/reissue`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      response.
+    } catch (error) {
+      console.error(error);
+    }
+    */
+    return false;
+  } else {
+    return true;
+  }
+};

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,4 +1,4 @@
-export const checkAuth = async () => {
+function checkAuth() {
   const tokenString = localStorage.getItem('accessToken');
   if (!tokenString) {
     return false;
@@ -26,4 +26,6 @@ export const checkAuth = async () => {
   } else {
     return true;
   }
-};
+}
+
+export default checkAuth;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import store from './store/store';
+import { Provider } from 'react-redux';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
-  <React.StrictMode>
+  <Provider store={store}>
     <App />
-  </React.StrictMode>,
+  </Provider>,
 );

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -33,7 +33,7 @@ export interface ValidityResults {
 }
 
 function Login() {
-  const [isSigned, setIsSigned] = useState(false);
+  const [keepLoggedIn, setKeepLoggedIn] = useState(false);
   const [loginForm, setLoginForm] = useState<LoginValue>({
     email: '',
     password: '',
@@ -49,7 +49,7 @@ function Login() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    await postLogin(loginForm);
+    await postLogin(loginForm, keepLoggedIn);
   };
 
   const changeEmailAndPasswordValueHandler = (
@@ -69,7 +69,7 @@ function Login() {
   };
 
   const clickSignedHandler = () => {
-    setIsSigned(!isSigned);
+    setKeepLoggedIn(!keepLoggedIn);
   };
 
   /* 
@@ -115,7 +115,10 @@ function Login() {
             Forgot password?
           </S_LinkTo>
           <S_CheckBoxContainer>
-            <CheckBox isChecked={isSigned} onClickEvent={clickSignedHandler}>
+            <CheckBox
+              isChecked={keepLoggedIn}
+              onClickEvent={clickSignedHandler}
+            >
               Stay signed in
             </CheckBox>
           </S_CheckBoxContainer>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import {
   S_LinkTo,
   S_ImgContainer,
@@ -20,7 +21,8 @@ import LoginLogo from '../../components/Login/LoginLogo/LoginLogo';
 import GoogleButton from '../../components/Login/GoogleButton/GoogleButton';
 import { S_InputContainerWrap } from '../../components/Login/Input/Input.styles';
 import { validateLogin } from '../../components/Login/LoginValidationLogic/LoginValidationLogic';
-import postLogin from '../../api/Login';
+import { postLogin } from '../../api/Login';
+import { loginSuccess } from '../../store/authSlice';
 
 export interface LoginValue {
   email: string;
@@ -33,6 +35,7 @@ export interface ValidityResults {
 }
 
 function Login() {
+  const dispatch = useDispatch();
   const [keepLoggedIn, setKeepLoggedIn] = useState(false);
   const [loginForm, setLoginForm] = useState<LoginValue>({
     email: '',
@@ -47,9 +50,10 @@ function Login() {
     validateLogin({ loginForm, setValidations });
   }, [loginForm]);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     await postLogin(loginForm, keepLoggedIn);
+    await dispatch(loginSuccess());
   };
 
   const changeEmailAndPasswordValueHandler = (
@@ -68,22 +72,15 @@ function Login() {
     }
   };
 
-  const clickSignedHandler = () => {
+  const clickkeepLoggedInHandler = () => {
     setKeepLoggedIn(!keepLoggedIn);
   };
-
-  /* 
-  ! 기능 구현할 때 참고할 주석입니다.
-  ? Login 버튼 눌렀을 때
-    1. email value가 ''이 아니고, password value가 ''이 아닐 것
-    2. isAllValid.email과 isAllValid.password가 true일 것
-  */
 
   return (
     <S_LoginContainerWrap>
       <S_ImgContainer />
       <S_ContentSection>
-        <S_LoginContainer onSubmit={handleSubmit}>
+        <S_LoginContainer onSubmit={handleLogin}>
           <LoginLogo />
           <S_InputContainerWrap>
             <EmailInput
@@ -117,7 +114,7 @@ function Login() {
           <S_CheckBoxContainer>
             <CheckBox
               isChecked={keepLoggedIn}
-              onClickEvent={clickSignedHandler}
+              onClickEvent={clickkeepLoggedInHandler}
             >
               Stay signed in
             </CheckBox>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -20,6 +20,7 @@ import LoginLogo from '../../components/Login/LoginLogo/LoginLogo';
 import GoogleButton from '../../components/Login/GoogleButton/GoogleButton';
 import { S_InputContainerWrap } from '../../components/Login/Input/Input.styles';
 import { validateLogin } from '../../components/Login/LoginValidationLogic/LoginValidationLogic';
+import postLogin from '../../api/Login';
 
 export interface LoginValue {
   email: string;
@@ -45,6 +46,11 @@ function Login() {
   useEffect(() => {
     validateLogin({ loginForm, setValidations });
   }, [loginForm]);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await postLogin(loginForm);
+  };
 
   const changeEmailAndPasswordValueHandler = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -77,7 +83,7 @@ function Login() {
     <S_LoginContainerWrap>
       <S_ImgContainer />
       <S_ContentSection>
-        <S_LoginContainer>
+        <S_LoginContainer onSubmit={handleSubmit}>
           <LoginLogo />
           <S_InputContainerWrap>
             <EmailInput

--- a/client/src/pages/Signup/Signup.tsx
+++ b/client/src/pages/Signup/Signup.tsx
@@ -41,7 +41,7 @@ function Signup() {
     validateLogin({ loginForm, setValidations });
   }, [loginForm]);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (isCheckedTerms) {
@@ -84,7 +84,7 @@ function Signup() {
     <S_LoginContainerWrap>
       <S_ImgContainer />
       <S_ContentSection>
-        <S_LoginContainer onSubmit={handleSubmit}>
+        <S_LoginContainer onSubmit={handleSignup}>
           <LoginLogo />
           <S_InputContainerWrap>
             <EmailInput

--- a/client/src/store/authSlice.ts
+++ b/client/src/store/authSlice.ts
@@ -1,11 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import checkAuth from '../api/Auth';
 
 type AuthState = {
   isLoggedIn: boolean;
 };
 
 const initialState: AuthState = {
-  isLoggedIn: false,
+  isLoggedIn: checkAuth(),
 };
 
 const authSlice = createSlice({

--- a/client/src/store/authSlice.ts
+++ b/client/src/store/authSlice.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type AuthState = {
+  isLoggedIn: boolean;
+};
+
+const initialState: AuthState = {
+  isLoggedIn: false,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    loginSuccess: (state) => {
+      state.isLoggedIn = true;
+    },
+    logoutSuccess: (state) => {
+      state.isLoggedIn = false;
+    },
+    setLoggedIn: (state, action: PayloadAction<boolean>) => {
+      state.isLoggedIn = action.payload;
+    },
+  },
+});
+
+export const { loginSuccess, logoutSuccess, setLoggedIn } = authSlice.actions;
+export default authSlice.reducer;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,0 +1,24 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+const store = configureStore({
+  reducer: rootReducer,
+});
+
+export default store;
+
+/*
+다음과 같이 auth state 값을 확인할 수 있습니다.
+
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
+
+! state 상태를 ts로 정의해 주어야 함으로 아래와 같이 RootState 타입을 import 해 지정합니다.
+const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
+*/


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #145
- 이슈 번호: #146

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
-  Login 클릭 시, 로그인 post 요청
- Login 유지 버튼 클릭 시, 유지(accessToken 로컬 스토리지 저장)
- 로그인 상태 Redux 추가

## 🔥 변경 로직
<!-- 변경된 로직이 있다면 적어주세요. -->
```tsx
export const postLogin = async (
  loginForm: LoginValue,
  keepLoggedIn: boolean,
) => {
  try {
    const response = await axios.post<undefined, AxiosResponse<ErrorResponse>>(
      `${import.meta.env.VITE_APP_API_URL}/api/auth/login`,
      {
        email: loginForm.email,
        password: loginForm.password,
      },
    );
    const accessToken: string | undefined =
      response.headers.authorization.replace(/^Bearer /, '');

    if (keepLoggedIn) {
      if (accessToken) {
        const expirationTime = new Date().getTime() + 5 * 60 * 60 * 1000;
        localStorage.setItem(
          'accessToken',
          JSON.stringify({
            token: accessToken,
            expiresAt: expirationTime,
          }),
        );
      }
    }
    window.history.back();
  } catch (error: unknown) {
    if (error instanceof AxiosError) {
      if (error.response) {
        const errorResponse: ErrorResponse = error.response.data.message;
        alert(errorResponse);
      }
    }
  }
};
```



### 📸 스크린샷
<!-- 관련 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
![image](https://user-images.githubusercontent.com/116181346/226626753-580598ba-3edf-493f-b9b1-8149c2fe3821.png)

![image](https://user-images.githubusercontent.com/116181346/226626655-f561da16-5f3e-46be-8a57-a16b58d501fb.png)
- 첫번째 이미지와 같이 Stay signed in 버튼을 눌러야만 로컬 스토리지에 accessToken이 저장됩니다.

![image](https://user-images.githubusercontent.com/116181346/226627016-e9b3efd1-c7c7-4f22-a7a1-7e2a296d57f5.png)

- 이메일과 비밀번호 모두 입력하지 않았을 때 팝업을 띄우도록 했습니다. (`+` 하나만 입력 시에도 팝업으로 오류 메시지가 출력 됩니다.)

### 👓 고민사항
> 1. accessToken 유효 시간을 임의로 5시간으로 설정해 두었는데 얼마 정도가 괜찮을까요?

> 2. 로그인 부분을 기능적으로 처음 구현해 보았는데 이렇게 하는 건가 맞나 싶네요,,,, 코드 리뷰 부탁합니다...!

### 📩 전달사항
> https가 적용되면 accessToken 만료 시, Refresh token을 통해 재발급받는 부분을 추가하겠습니다. 
> 풀리를 나눠 올리려고 했는데 한 브랜치에 올려 하나로 뭉쳐졌네요! Rudex 추가했습니다... `src\store\store.ts` 주석을 참고해 auth의 상태값에 접근하시길 바랍니다!