### PR TITLE
[Feat] 메인 화면에서 좋아요 순으로 이미지 10개 조회 기능 추가

### DIFF
--- a/server/src/main/java/com/photoday/photoday/image/controller/ImageController.java
+++ b/server/src/main/java/com/photoday/photoday/image/controller/ImageController.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/images")
@@ -81,5 +82,11 @@ public class ImageController {
     public ResponseEntity<?> getUserImages(@PathVariable @Positive Long userId, Pageable pageable) {
         MultiResponseDto userImages = imageService.getUserImages(userId, pageable);
         return new ResponseEntity<>(userImages, HttpStatus.OK);
+    }
+
+    @GetMapping("/main")
+    public ResponseEntity<?> getMainImages() {
+        List<ImageDto.Response> mainImages = imageService.getMainImages();
+        return new ResponseEntity<>(mainImages, HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/photoday/photoday/image/repository/ImageRepository.java
+++ b/server/src/main/java/com/photoday/photoday/image/repository/ImageRepository.java
@@ -24,4 +24,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     Page<Image> findAllUserImages(Pageable pageable, Long userId);
 
     boolean existsByImageHashValue(String imageHashValue);
+
+    @Query(value = "SELECT i FROM Image i ORDER BY i.likeList.size DESC")
+    Page<Image> findMainImages(Pageable pageable);
 }

--- a/server/src/main/java/com/photoday/photoday/image/service/ImageService.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 public interface ImageService {
     ImageDto.Response createImage(TagDto post, MultipartFile multipartFile) throws IOException, NoSuchAlgorithmException;
@@ -28,6 +29,8 @@ public interface ImageService {
     ImageDto.Response updateLike(long imageId);
 
     MultiResponseDto getUserImages(long userId, Pageable pageable);
+
+    List<ImageDto.Response> getMainImages();
 
     Image findVerifiedImage(long imageId);
 }

--- a/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -215,6 +216,15 @@ public class ImageServiceImpl implements ImageService {
                 = imageList.stream().map(imageMapper::imageToPageResponse).collect(Collectors.toList());
 
         return new MultiResponseDto(responses, page);
+    }
+
+    @Override
+    public List<ImageDto.Response> getMainImages() {
+        Pageable pageRequest = PageRequest.of(0, 10);
+        Page<Image> page = imageRepository.findMainImages(pageRequest);
+        List<Image> mainImages = page.getContent();
+        List<ImageDto.Response> responses = mainImages.stream().map(imageMapper::imageToResponse).collect(Collectors.toList());
+        return responses;
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요
- 이슈 번호: #120 

## ✨ 개발 내용
메인 화면에서 나타나는 사진 조회 기능 추가. 
좋아요 많은 순서로 10개가 리스트로 반환됩니다. 

## 🔥 변경 로직(optional)

### 📸 스크린샷(optional)

### 👓 고민사항(optional)

### 📩 전달사항(optional)

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)
