### PR TITLE
[Feature] User page 기능 구현(Tap별 게시물 요청, 로그아웃, 게시물 없을 때 UI)

### DIFF
--- a/client/src/api/User.ts
+++ b/client/src/api/User.ts
@@ -47,7 +47,7 @@ export const deleteUser = async () => {
   });
 
   localStorage.removeItem('accessToken');
-  localStorage.removeItem('userId');
+  localStorage.removeItem('id');
 };
 
 export const updateUser = async (textareaValue: string) => {

--- a/client/src/api/User.ts
+++ b/client/src/api/User.ts
@@ -143,10 +143,13 @@ type ImageListResponse = {
 export const getUserPosts = async (
   userId: string | null | undefined,
   paginate: number,
+  currentTap: string,
 ) => {
   const token = localStorage.getItem('accessToken');
   const response = await axios.get<ImageListResponse>(
-    `${import.meta.env.VITE_APP_API}/images/user/${userId}`,
+    currentTap === 'user'
+      ? `${import.meta.env.VITE_APP_API}/images/user/${userId}`
+      : `${import.meta.env.VITE_APP_API}/images/bookmarks`,
     {
       headers: {
         Authorization: token,

--- a/client/src/components/User/UserContentSection/UserContentSection.styles.tsx
+++ b/client/src/components/User/UserContentSection/UserContentSection.styles.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Flex, ColFlex } from '../../../styles/GlobalStyles';
 
 export const S_UserPageSubTitleWrap = styled.div<{ currentTap: string }>`
   display: flex;
@@ -34,11 +35,25 @@ export const S_Tab = styled.div`
 `;
 
 export const S_UserPhotoContentContainer = styled.article`
-  display: flex;
-  justify-content: center;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   padding: 30px 8%;
   place-items: center;
   gap: 20px;
+`;
+
+export const S_NoPostsGuideContainer = styled.div`
+  ${ColFlex}
+  align-items: center;
+  margin: 10% 0;
+`;
+
+export const S_NoPostsGuideIcon = styled.i`
+  color: var(--color-primary-green);
+`;
+
+export const S_NoPostsGuide = styled.span`
+  color: var(--color-primary-black);
+  font-size: var(--font-size-l);
+  margin: 15px 0;
 `;

--- a/client/src/components/User/UserContentSection/UserContentSection.tsx
+++ b/client/src/components/User/UserContentSection/UserContentSection.tsx
@@ -3,12 +3,18 @@ import {
   S_UserPageSubTitleWrap,
   S_UserPageSubTitlePoint,
   S_UserPhotoContentContainer,
+  S_NoPostsGuideContainer,
+  S_NoPostsGuideIcon,
+  S_NoPostsGuide,
   S_Tab,
 } from './UserContentSection.styles';
 import { S_ImageCardBox } from '../../common/ImageCardList/ImageCardList.styles';
 import { getUserPosts, PageInfo, Image } from '../../../api/User';
 import Pagination from '../../common/Pagination/Pagination';
 import ImageCard from '../../common/ImageCard/ImageCard';
+import { CiImageOff, CiCamera } from 'react-icons/ci';
+import { MdOutlinePhotoCamera } from 'react-icons/md';
+import { BsCamera } from 'react-icons/bs';
 
 type User = {
   userName: string;
@@ -70,19 +76,39 @@ function UserContentSection({ userName, isMyPage, id, userId }: User) {
           </S_Tab>
         )}
       </S_UserPageSubTitleWrap>
-      <S_UserPhotoContentContainer>
-        {posts.map((post: Image) => (
-          <S_ImageCardBox
-            key={post.imageId}
-            width={240}
-            height={220}
-            matrix="columns"
-          >
-            <ImageCard item={post} />
-          </S_ImageCardBox>
-        ))}
-      </S_UserPhotoContentContainer>
-      <Pagination pagination={pagination} setPaginate={setPaginate} />
+      {posts.length ? (
+        <>
+          <S_UserPhotoContentContainer>
+            {posts.map((post: Image) => (
+              <S_ImageCardBox
+                key={post.imageId}
+                width={240}
+                height={220}
+                matrix="columns"
+              >
+                <ImageCard item={post} />
+              </S_ImageCardBox>
+            ))}
+          </S_UserPhotoContentContainer>
+          <Pagination pagination={pagination} setPaginate={setPaginate} />
+        </>
+      ) : (
+        // 아이콘 문구 고민 중
+        <S_NoPostsGuideContainer>
+          <S_NoPostsGuideIcon>
+            <CiImageOff size={150} />
+          </S_NoPostsGuideIcon>
+          <S_NoPostsGuide>No posts found</S_NoPostsGuide>
+          {/* <S_NoPostsGuideIcon>
+            <CiCamera size={150} />
+          </S_NoPostsGuideIcon>
+          <S_NoPostsGuide>No posts found</S_NoPostsGuide> */}
+          {/* <S_NoPostsGuideIcon>
+            <BsCamera size={130} />
+          </S_NoPostsGuideIcon>
+          <S_NoPostsGuide>Have no posts</S_NoPostsGuide> */}
+        </S_NoPostsGuideContainer>
+      )}
     </>
   );
 }

--- a/client/src/components/User/UserContentSection/UserContentSection.tsx
+++ b/client/src/components/User/UserContentSection/UserContentSection.tsx
@@ -31,7 +31,11 @@ function UserContentSection({ userName, isMyPage, id, userId }: User) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await getUserPosts(isMyPage ? id : userId, paginate);
+        const response = await getUserPosts(
+          isMyPage ? id : userId,
+          paginate,
+          currentTap,
+        );
         const postData = response.data;
         const paginationData: PageInfo = response.pageInfo;
         setPosts(postData);
@@ -41,7 +45,7 @@ function UserContentSection({ userName, isMyPage, id, userId }: User) {
       }
     };
     fetchData();
-  }, [paginate]);
+  }, [paginate, currentTap]);
 
   const userTapHandler = () => {
     setCurrentTap('user');

--- a/client/src/components/User/UserContentSection/UserContentSection.tsx
+++ b/client/src/components/User/UserContentSection/UserContentSection.tsx
@@ -68,7 +68,12 @@ function UserContentSection({ userName, isMyPage, id, userId }: User) {
       </S_UserPageSubTitleWrap>
       <S_UserPhotoContentContainer>
         {posts.map((post: Image) => (
-          <S_ImageCardBox key={post.imageId} width={240} height={220}>
+          <S_ImageCardBox
+            key={post.imageId}
+            width={240}
+            height={220}
+            matrix="columns"
+          >
             <ImageCard item={post} />
           </S_ImageCardBox>
         ))}

--- a/client/src/components/User/UserContentSection/UserContentSection.tsx
+++ b/client/src/components/User/UserContentSection/UserContentSection.tsx
@@ -51,14 +51,16 @@ function UserContentSection({ userName, isMyPage, id, userId }: User) {
       }
     };
     fetchData();
-  }, [paginate, currentTap]);
+  }, [paginate, currentTap, userId]);
 
   const userTapHandler = () => {
     setCurrentTap('user');
+    setPaginate(1);
   };
 
   const bookmarkTapHandler = () => {
     setCurrentTap('bookmark');
+    setPaginate(1);
   };
 
   return (

--- a/client/src/components/common/Header/HeaderModal.tsx
+++ b/client/src/components/common/Header/HeaderModal.tsx
@@ -7,6 +7,11 @@ import {
   S_ModalNavLink,
 } from './HeaderModal.styles';
 
+const logoutHandler = () => {
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('id');
+};
+
 function HeaderModal() {
   return (
     <S_HeaderModalWrap>
@@ -16,7 +21,9 @@ function HeaderModal() {
       </S_ModalNavBox>
       <S_ModalNavBox>
         <IoLogOut className="logout-icon" />
-        <S_ModalNavLink to="/logout">Logout</S_ModalNavLink>
+        <S_ModalNavLink to="/" onClick={logoutHandler}>
+          Logout
+        </S_ModalNavLink>
       </S_ModalNavBox>
     </S_HeaderModalWrap>
   );

--- a/client/src/components/common/Pagination/Pagination.styles.tsx
+++ b/client/src/components/common/Pagination/Pagination.styles.tsx
@@ -15,7 +15,7 @@ export const S_PageButton = styled.button`
 
   &:hover {
     color: var(--white);
-    background-color: #3cb46e75;
+    background-color: #67cd92;
   }
 `;
 

--- a/client/src/pages/User/User.tsx
+++ b/client/src/pages/User/User.tsx
@@ -27,7 +27,7 @@ function Users() {
       }
     };
     fetchData();
-  }, []);
+  }, [userData]);
 
   return (
     <ContainerWrap>

--- a/client/src/pages/User/User.tsx
+++ b/client/src/pages/User/User.tsx
@@ -27,7 +27,7 @@ function Users() {
       }
     };
     fetchData();
-  }, [userData]);
+  }, [userId]);
 
   return (
     <ContainerWrap>


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #169
- 이슈 번호: #188

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- Tap 별(유저 포스트 게시글, 본인일 때 북마크한 게시물) 게시물 요청
- 헤더 모달 로그아웃 클릭 시 토큰 삭제(로그아웃 구현)
- 게시물 없을 때 나오는 UI 구현

## 🔥 변경 로직
<!-- 변경된 로직이 있다면 적어주세요. -->
- 게시물이 있을 때만 게시물을 띄우고 없을 시, 페이지네이션이 보이지 않고 아래 사진(스크린샷 참고)처럼 나옵니다.
```tsx
  {posts.length ? (
        <>
          <S_UserPhotoContentContainer>
            {posts.map((post: Image) => (
              <S_ImageCardBox
                key={post.imageId}
                width={240}
                height={220}
                matrix="columns"
              >
                <ImageCard item={post} />
              </S_ImageCardBox>
            ))}
          </S_UserPhotoContentContainer>
          <Pagination pagination={pagination} setPaginate={setPaginate} />
        </>
      ) : (
        <S_NoPostsGuideContainer>
          <S_NoPostsGuideIcon>
            <CiImageOff size={150} />
          </S_NoPostsGuideIcon>
          <S_NoPostsGuide>No posts found</S_NoPostsGuide>
        </S_NoPostsGuideContainer>
      )}
```

### 📸 스크린샷
- [게시물 없을 때 나오는 UI] 디스코드에서 투표가 끝나면 투표 결과를 반영해서 결정해서 올리겠습니다!
![image](https://user-images.githubusercontent.com/116181346/227492157-2af74993-778a-4f49-ae4f-38f02d2ce8b9.png)
![image](https://user-images.githubusercontent.com/116181346/227492184-19f34dd6-47c7-481c-8825-5a8b236c5f8a.png)
![image](https://user-images.githubusercontent.com/116181346/227492204-c8544089-d165-4ff3-82e5-c1fc0d125ce9.png)

- 북마크 클릭 시
![image](https://user-images.githubusercontent.com/116181346/227492873-cb17a5c4-1fc9-44b5-9eaf-94f5ee573811.png)

### 📩 전달사항
- 페이지네이션 호버색은 상의했던대로 태그 색상과 동일하게 메인 컬러에서 살짝 연한 색으로 통일시켰습니다!