### PR TITLE
Feat/test 테스트에 수정사항 적용, 리팩토링

### DIFF
--- a/server/src/main/java/com/photoday/photoday/image/mapper/ImageMapper.java
+++ b/server/src/main/java/com/photoday/photoday/image/mapper/ImageMapper.java
@@ -2,10 +2,9 @@ package com.photoday.photoday.image.mapper;
 
 import com.photoday.photoday.image.dto.ImageDto;
 import com.photoday.photoday.image.entity.Image;
-import com.photoday.photoday.security.service.AuthUserService;
 import com.photoday.photoday.user.dto.UserDto;
+import com.photoday.photoday.user.entity.User;
 import com.photoday.photoday.user.mapper.UserMapper;
-import com.photoday.photoday.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -17,8 +16,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ImageMapper {
     private final UserMapper userMapper;
-    private final AuthUserService authUserService;
-    private final UserService userService;
 
     public ImageDto.PageResponse imageToPageResponse(Image image){
         return ImageDto.PageResponse.builder()
@@ -29,10 +26,10 @@ public class ImageMapper {
                 .build();
     }
 
-    public ImageDto.Response imageToResponse(Image image) {
+    public ImageDto.Response imageToResponse(Image image, User loginUser) {
         return ImageDto.Response.builder()
                 .imageId(image.getImageId())
-                .owner(getOwner(image))
+                .owner(getOwner(image, loginUser))
                 .imageUrl(image.getImageUrl())
                 .like(hasLiked(image))
                 .likeCount(image.getLikeList().size())
@@ -78,9 +75,11 @@ public class ImageMapper {
                 .anyMatch(like -> like.getUser().getEmail().equals(email));
     }
 
-    private UserDto.Response getOwner(Image image) {
-        Long loginUserId = authUserService.checkLogin();
-        boolean checkAdmin = userService.checkAdmin(loginUserId);
-        return userMapper.userToUserResponse(image.getUser(), loginUserId, checkAdmin);
+    private UserDto.Response getOwner(Image image, User loginUser) {
+//        Long loginUserId = authUserService.checkLogin();
+//        boolean checkAdmin = userService.checkAdmin(loginUserId);
+//        User loginUser = authUserService.getLoginUser().orElseGet(null);
+
+        return userMapper.userToUserResponse(image.getUser(), loginUser);
     }
 }

--- a/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
@@ -2,7 +2,6 @@ package com.photoday.photoday.image.service.impl;
 
 import com.photoday.photoday.dto.MultiResponseDto;
 import com.photoday.photoday.excpetion.CustomException;
-import com.photoday.photoday.excpetion.ExceptionCode;
 import com.photoday.photoday.image.dto.ImageDto;
 import com.photoday.photoday.image.entity.*;
 import com.photoday.photoday.image.mapper.ImageMapper;
@@ -22,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,8 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.photoday.photoday.excpetion.ExceptionCode.ALREADY_REPORTED;
-import static com.photoday.photoday.excpetion.ExceptionCode.IMAGE_NOT_FOUND;
+import static com.photoday.photoday.excpetion.ExceptionCode.*;
 
 @Service(value = "imageService")
 @Transactional
@@ -57,18 +54,19 @@ public class ImageServiceImpl implements ImageService {
     public ImageDto.Response createImage(TagDto post, MultipartFile multipartFile) throws IOException, NoSuchAlgorithmException {
         if (!List.of("image/jpeg", "image/pjpeg", "image/tiff", "image/png", "image/bmp", "image/x-windows-bmp")
                 .contains(multipartFile.getContentType())) {
-            throw new CustomException(ExceptionCode.IMAGE_FILE_ONLY);
+            throw new CustomException(IMAGE_FILE_ONLY);
         }
 
         String imageHashValue = s3Service.getMd5Hash(multipartFile);
         if (imageRepository.existsByImageHashValue(imageHashValue)) {
-            throw new CustomException(ExceptionCode.DUPLICATE_IMAGE);
+            throw new CustomException(DUPLICATE_IMAGE);
         }
-
-        Long userId = authUserService.getLoginUserId();
+        User user = authUserService.getLoginUser()
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+//        Long userId = authUserService.getLoginUserId();
 
         String imageUrl = s3Service.saveImage(multipartFile);
-        Image image = makeImage(imageUrl, userId);
+        Image image = makeImage(imageUrl, user);
         image.setImageHashValue(imageHashValue);
 
         List<Tag> tagList = tagMapper.dtoToTag(post);
@@ -76,21 +74,22 @@ public class ImageServiceImpl implements ImageService {
         image.setImageTagList(imageTagList);
 
         Image save = imageRepository.save(image);
-        return imageMapper.imageToResponse(save);
+        return imageMapper.imageToResponse(save, user);
     }
 
     @Override
     public ImageDto.Response updateImageTags(long imageId, TagDto patch) {
         Image image = findVerifiedImage(imageId); // 이미지 존재하는지 검증
-
-        Long userId = authUserService.getLoginUserId();
-        if (!Objects.equals(image.getUser().getUserId(), userId)) throw new CustomException(ExceptionCode.NOT_IMAGE_OWNER);
+        User user = authUserService.getLoginUser().orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+//        Long userId = authUserService.getLoginUserId();
+        if (!Objects.equals(image.getUser().getUserId(), user.getUserId()))
+            throw new CustomException(NOT_IMAGE_OWNER);
 
         List<Tag> tagList = tagMapper.dtoToTag(patch);
         image.getImageTagList().clear();
         tagListToImageTagList(tagList, image);
 
-        return imageMapper.imageToResponse(image);
+        return imageMapper.imageToResponse(image, user);
     }
 
     @Override
@@ -98,25 +97,29 @@ public class ImageServiceImpl implements ImageService {
         Image image = findVerifiedImage(imageId);
         image.setViewCount(image.getViewCount() + 1);
         Image save = imageRepository.save(image);
-        return imageMapper.imageToResponse(save);
+        User user = authUserService.getLoginUser().orElse(null);
+        return imageMapper.imageToResponse(save, user);
     }
 
     @Override
     public void deleteImage(long imageId) {
         Image image = findVerifiedImage(imageId);
-        Long userId = authUserService.getLoginUserId();
-        if (!Objects.equals(image.getUser().getUserId(), userId)) throw new CustomException(ExceptionCode.NOT_IMAGE_OWNER);
+//        Long userId = authUserService.getLoginUserId();
+        User user = authUserService.getLoginUser().orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        if (!image.getUser().getUserId().equals(user.getUserId()))
+            throw new CustomException(NOT_IMAGE_OWNER);
         imageRepository.deleteById(imageId);
     }
 
     @Override
     public ImageDto.Response updateBookmark(long imageId) {
         Image image = findVerifiedImage(imageId);
-        Long userId = authUserService.getLoginUserId();
-        User user = userService.findVerifiedUser(userId);
+        User user = authUserService.getLoginUser().orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+//        Long userId = authUserService.getLoginUserId();
+//        User user = userService.findVerifiedUser(userId);
 
         Optional<Bookmark> bookmark = image.getBookmarkList().stream()
-                .filter(b -> Objects.equals(b.getUser().getUserId(), userId))
+                .filter(b -> b.getUser().getUserId().equals(user.getUserId()))
                 .findFirst();
 
         if (bookmark.isPresent()) {
@@ -128,7 +131,7 @@ public class ImageServiceImpl implements ImageService {
             newBookmark.setImage(image);
         }
 
-        return imageMapper.imageToResponse(image);
+        return imageMapper.imageToResponse(image, user);
     }
 
     @Override
@@ -148,16 +151,18 @@ public class ImageServiceImpl implements ImageService {
     public ImageDto.Response createReport(long imageId) {
         Image image = findVerifiedImage(imageId);
 
-        Long userId = authUserService.getLoginUserId();
-        if (Objects.equals(image.getUser().getUserId(), userId)) {
-            throw new CustomException(ExceptionCode.CANNOT_REPORT_MYSELF);
+        User loginUser = authUserService.getLoginUser()
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+//        Long userId = authUserService.getLoginUserId();
+        if (image.getUser().getUserId().equals(loginUser.getUserId())) {
+            throw new CustomException(CANNOT_REPORT_MYSELF);
         }
 
-        User user = userService.findVerifiedUser(userId);
-        userService.checkUserReportCount(userId);
+//        User loginUser = userService.findVerifiedUser(userId);
+        userService.checkUserReportCount(loginUser);
 
         Optional<Report> optionalReport = image.getReportList().stream()
-                .filter(r -> Objects.equals(r.getUser().getUserId(), userId))
+                .filter(r -> r.getUser().getUserId().equals(loginUser.getUserId()))
                 .findFirst();
 
         if (image.getReportList().size() >= 4) {
@@ -170,7 +175,7 @@ public class ImageServiceImpl implements ImageService {
         } else {
             //아니면 신고 목록에 추가 및 저장
             Report report = new Report();
-            report.setUser(user);
+            report.setUser(loginUser);
             report.setImage(image);
 
             //회원 정지 기능 //TODO 회원 서비스로 빼기
@@ -181,17 +186,19 @@ public class ImageServiceImpl implements ImageService {
             }
         }
 
-        return imageMapper.imageToResponse(image);
+        return imageMapper.imageToResponse(image, loginUser);
     }
 
     @Override
     public ImageDto.Response updateLike(long imageId) {
         Image image = findVerifiedImage(imageId);
-        Long userId = authUserService.getLoginUserId(); //TODO 리팩토링 필요
-        User user = userService.findVerifiedUser(userId);
+//        Long userId = authUserService.getLoginUserId(); //TODO 리팩토링 필요
+//        User user = userService.findVerifiedUser(userId);
+        User loginUser = authUserService.getLoginUser()
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         Optional<Like> like = image.getLikeList().stream()
-                .filter(l -> Objects.equals(l.getUser().getUserId(), userId))
+                .filter(l -> Objects.equals(l.getUser().getUserId(), loginUser.getUserId()))
                 .findFirst();
 
         if (like.isPresent()) {
@@ -199,11 +206,11 @@ public class ImageServiceImpl implements ImageService {
             likeRepository.deleteAllByIdInBatch(Collections.singleton(like.get().getLikeId()));
         } else {
             Like newLike = new Like();
-            newLike.setUser(user);
+            newLike.setUser(loginUser);
             newLike.setImage(image);
         }
 
-        return imageMapper.imageToResponse(image);
+        return imageMapper.imageToResponse(image, loginUser);
     }
 
     @Override
@@ -223,7 +230,10 @@ public class ImageServiceImpl implements ImageService {
         Pageable pageRequest = PageRequest.of(0, 10);
         Page<Image> page = imageRepository.findMainImages(pageRequest);
         List<Image> mainImages = page.getContent();
-        List<ImageDto.Response> responses = mainImages.stream().map(imageMapper::imageToResponse).collect(Collectors.toList());
+        User user = authUserService.getLoginUser().orElse(null);
+        List<ImageDto.Response> responses = mainImages.stream()
+                .map(image -> imageMapper.imageToResponse(image, user))
+                .collect(Collectors.toList());
         return responses;
     }
 
@@ -233,8 +243,8 @@ public class ImageServiceImpl implements ImageService {
         return optionalImage.orElseThrow(() -> new CustomException(IMAGE_NOT_FOUND));
     }
 
-    private Image makeImage(String imageUrl, Long userId) {
-        User user = userService.findVerifiedUser(userId);
+    private Image makeImage(String imageUrl, User user) {
+//        User user = userService.findVerifiedUser(userId);
 
         Image image = new Image();
         image.setImageUrl(imageUrl);

--- a/server/src/main/java/com/photoday/photoday/security/service/AuthUserService.java
+++ b/server/src/main/java/com/photoday/photoday/security/service/AuthUserService.java
@@ -1,11 +1,17 @@
 package com.photoday.photoday.security.service;
 
+import com.photoday.photoday.user.entity.User;
+
+import java.util.Optional;
+
 public interface AuthUserService {
     Long getLoginUserId();
 
     Long checkLogin();
 
     String getLoginUserEmail();
+
+    Optional<User> getLoginUser();
 
     void setNewPassword(String email);
 }

--- a/server/src/main/java/com/photoday/photoday/security/service/impl/AuthUserServiceImpl.java
+++ b/server/src/main/java/com/photoday/photoday/security/service/impl/AuthUserServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AuthUserServiceImpl implements AuthUserService {
@@ -39,6 +41,12 @@ public class AuthUserServiceImpl implements AuthUserService {
     public String getLoginUserEmail() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getName();
+    }
+
+    @Override
+    public Optional<User> getLoginUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return userRepository.findByEmail(authentication.getName());
     }
 
     @Override

--- a/server/src/main/java/com/photoday/photoday/user/mapper/UserMapper.java
+++ b/server/src/main/java/com/photoday/photoday/user/mapper/UserMapper.java
@@ -5,7 +5,7 @@ import com.photoday.photoday.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -30,25 +30,44 @@ public class UserMapper {
         return user;
     }
 
-    public UserDto.Response userToUserResponse(User targetUser, Long userId, boolean checkAdmin) { //TODO 팔로우 확인
-        boolean checkFollow = userId != null && targetUser.getFollower().stream().anyMatch(fw -> Objects.equals(fw.getFollowing().getUserId(), userId));
-
+    public UserDto.Response userToUserResponse(User targetUser, User user) { //TODO 팔로우 확인
         UserDto.Response response = new UserDto.Response();
 
         response.setUserId(targetUser.getUserId());
         response.setName(targetUser.getName());
         response.setProfileImageUrl(targetUser.getProfileImageUrl());
         response.setDescription(targetUser.getDescription());
-        response.setCheckFollow(checkFollow);
+        response.setCheckFollow(checkFollow(targetUser, user));
         response.setLikeCount(targetUser.getLikes() != null ? targetUser.getLikes().size() : 0);
         response.setReportCount(targetUser.getReports() != null ? targetUser.getReports().size() : 0);
         response.setFollowerCount(targetUser.getFollower() != null ? targetUser.getFollower().size() : 0);
         response.setFollowingCount(targetUser.getFollowing() != null ? targetUser.getFollowing().size() : 0);
-        response.setMyPage(userId != null && userId.equals(targetUser.getUserId()));
-        response.setCheckAdmin(checkAdmin);
-
-        response.setMyPage(userId != null && userId.equals(targetUser.getUserId()));
+        response.setMyPage(user != null && user.getUserId().equals(targetUser.getUserId()));
+        response.setCheckAdmin(checkAdmin(user));
+        response.setMyPage(myPage(targetUser, user));
 
         return response;
+    }
+
+    private boolean checkFollow(User targetUser, User user) {
+        if (user == null) return false;
+
+        Long userId = user.getUserId();
+        return userId != null && targetUser.getFollower().stream()
+                .anyMatch(fw -> fw.getFollowing().getUserId().equals(userId));
+    }
+
+    private boolean checkAdmin(User user) {
+        if (user == null) return false;
+
+        List<String> roles = user.getRoles();
+        return roles.contains("ADMIN");
+    }
+
+    private boolean myPage(User targetUser, User user) {
+        if (user == null) return false;
+
+        Long userId = user.getUserId();
+        return userId != null && userId.equals(targetUser.getUserId());
     }
 }

--- a/server/src/main/java/com/photoday/photoday/user/mapper/UserMapper.java
+++ b/server/src/main/java/com/photoday/photoday/user/mapper/UserMapper.java
@@ -30,44 +30,44 @@ public class UserMapper {
         return user;
     }
 
-    public UserDto.Response userToUserResponse(User targetUser, User user) { //TODO 팔로우 확인
+    public UserDto.Response userToUserResponse(User targetUser, User loginUser) { //TODO 팔로우 확인
         UserDto.Response response = new UserDto.Response();
 
         response.setUserId(targetUser.getUserId());
         response.setName(targetUser.getName());
         response.setProfileImageUrl(targetUser.getProfileImageUrl());
         response.setDescription(targetUser.getDescription());
-        response.setCheckFollow(checkFollow(targetUser, user));
+        response.setCheckFollow(checkFollow(targetUser, loginUser));
         response.setLikeCount(targetUser.getLikes() != null ? targetUser.getLikes().size() : 0);
         response.setReportCount(targetUser.getReports() != null ? targetUser.getReports().size() : 0);
         response.setFollowerCount(targetUser.getFollower() != null ? targetUser.getFollower().size() : 0);
         response.setFollowingCount(targetUser.getFollowing() != null ? targetUser.getFollowing().size() : 0);
-        response.setMyPage(user != null && user.getUserId().equals(targetUser.getUserId()));
-        response.setCheckAdmin(checkAdmin(user));
-        response.setMyPage(myPage(targetUser, user));
+        response.setMyPage(loginUser != null && loginUser.getUserId().equals(targetUser.getUserId()));
+        response.setCheckAdmin(checkAdmin(loginUser));
+        response.setMyPage(myPage(targetUser, loginUser));
 
         return response;
     }
 
-    private boolean checkFollow(User targetUser, User user) {
-        if (user == null) return false;
+    private boolean checkFollow(User targetUser, User loginUser) {
+        if (loginUser == null) return false;
 
-        Long userId = user.getUserId();
+        Long userId = loginUser.getUserId();
         return userId != null && targetUser.getFollower().stream()
                 .anyMatch(fw -> fw.getFollowing().getUserId().equals(userId));
     }
 
-    private boolean checkAdmin(User user) {
-        if (user == null) return false;
+    private boolean checkAdmin(User loginUser) {
+        if (loginUser == null) return false;
 
-        List<String> roles = user.getRoles();
+        List<String> roles = loginUser.getRoles();
         return roles.contains("ADMIN");
     }
 
-    private boolean myPage(User targetUser, User user) {
-        if (user == null) return false;
+    private boolean myPage(User targetUser, User loginUser) {
+        if (loginUser == null) return false;
 
-        Long userId = user.getUserId();
+        Long userId = loginUser.getUserId();
         return userId != null && userId.equals(targetUser.getUserId());
     }
 }

--- a/server/src/main/java/com/photoday/photoday/user/service/UserService.java
+++ b/server/src/main/java/com/photoday/photoday/user/service/UserService.java
@@ -18,7 +18,7 @@ public interface UserService {
 
     User findVerifiedUser(Long userId);
 
-    void checkUserReportCount(Long userId);
+    void checkUserReportCount(User user);
 
     User findUserByEmail(String email);
 

--- a/server/src/test/java/com/photoday/photoday/helper/snippets/RestDocsSnippets.java
+++ b/server/src/test/java/com/photoday/photoday/helper/snippets/RestDocsSnippets.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.headers.RequestHeadersSnippet;
 import org.springframework.restdocs.headers.ResponseHeadersSnippet;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
@@ -28,8 +29,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -168,6 +168,12 @@ public class RestDocsSnippets {
         return new MultiResponseDto<>(content, page);
     }
 
+    public static RequestHeadersSnippet getRequestHeadersAccessToken() {
+        return requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("access-token. jwt 액세스 토큰")
+        );
+    }
+
     public static RequestParametersSnippet getRequestParameterImageDtoBookmarkAndSearchResponse() {
         return requestParameters(
                 parameterWithName("page").description("페이지 번호"),
@@ -208,7 +214,9 @@ public class RestDocsSnippets {
                 fieldWithPath("data.reportCount").type(JsonFieldType.NUMBER).description("받은 신고 수"),
                 fieldWithPath("data.followerCount").type(JsonFieldType.NUMBER).description("좋아요 받은 수"),
                 fieldWithPath("data.followingCount").type(JsonFieldType.NUMBER).description("좋아요 누른 수"),
-                fieldWithPath("data.checkFollow").type(JsonFieldType.BOOLEAN).description("follow 누른 유저인지 여부")
+                fieldWithPath("data.checkFollow").type(JsonFieldType.BOOLEAN).description("follow 누른 유저인지 여부"),
+                fieldWithPath("data.myPage").type(JsonFieldType.BOOLEAN).description("본인 페이지 인지 여부"),
+                fieldWithPath("data.checkAdmin").type(JsonFieldType.BOOLEAN).description("로그인 유저가 관리자인지 여부")
         );
     }
 
@@ -226,6 +234,8 @@ public class RestDocsSnippets {
                 fieldWithPath("data.owner.followerCount").type(JsonFieldType.NUMBER).description("이미지 등록한 유저 팔로우 받은 수"),
                 fieldWithPath("data.owner.followingCount").type(JsonFieldType.NUMBER).description("이미지 등록한 유저 팔로우 하는 수"),
                 fieldWithPath("data.owner.checkFollow").type(JsonFieldType.BOOLEAN).description("이미지 등록한 유저 팔로우헀는지 여부(본인인 경우 false)"),
+                fieldWithPath("data.owner.myPage").type(JsonFieldType.BOOLEAN).description("ㅇㅇ"),
+                fieldWithPath("data.owner.checkAdmin").type(JsonFieldType.BOOLEAN).description("이미지 등록한 유저 팔로우헀는지 여부(본인인 경우 false)"),
                 fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("이미지 Url"),
                 fieldWithPath("data.like").type(JsonFieldType.BOOLEAN).description("현재 유저의 이미지 좋아요 여부"),
                 fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("이미지 좋아요 받은 수"),

--- a/server/src/test/java/com/photoday/photoday/image/mapper/ImageMapperTest.java
+++ b/server/src/test/java/com/photoday/photoday/image/mapper/ImageMapperTest.java
@@ -6,6 +6,7 @@ import com.photoday.photoday.security.service.impl.AuthUserServiceImpl;
 import com.photoday.photoday.user.dto.UserDto;
 import com.photoday.photoday.user.entity.User;
 import com.photoday.photoday.user.mapper.UserMapper;
+import com.photoday.photoday.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +21,7 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 
@@ -34,6 +34,8 @@ class ImageMapperTest {
     UserMapper userMapper;
     @MockBean
     AuthUserServiceImpl authUserServiceImpl;
+    @MockBean
+    UserService userService;
 
     @Test
     @WithMockUser // default value로 username = “user”, password = “password”, role = “USER”
@@ -52,8 +54,7 @@ class ImageMapperTest {
 //        method.setAccessible(true);
 //        assertThrows(NullPointerException.class, ()->method.invoke(imageMapper, image));
 
-        given(authUserServiceImpl.checkLogin()).willReturn(null);
-        given(userMapper.userToUserResponse(Mockito.any(User.class), Mockito.anyLong(), anyBoolean())).willReturn(new UserDto.Response());
+        given(userMapper.userToUserResponse(Mockito.any(User.class), any(User.class))).willReturn(new UserDto.Response());
 
         // when
         ImageDto.PageResponse pageResponse = imageMapper.imageToPageResponse(image);
@@ -84,15 +85,14 @@ class ImageMapperTest {
         UserDto.Response responseUser = new UserDto.Response(1L, "홍길동", "profileImageUrl", "hi", 1, 1,
                 1, 1, false, false, false);
 
-        given(authUserServiceImpl.checkLogin()).willReturn(1L);
-        given(userMapper.userToUserResponse(Mockito.any(User.class), anyLong(), anyBoolean())).willReturn(responseUser);
+        given(userMapper.userToUserResponse(Mockito.any(User.class), any(User.class))).willReturn(responseUser);
+        given(userService.checkAdmin(anyLong())).willReturn(false);
 
         //when
-        ImageDto.Response response = imageMapper.imageToResponse(image);
+        ImageDto.Response response = imageMapper.imageToResponse(image, null);
 
         //then
         assertEquals(response.getImageId(), image.getImageId());
-        assertEquals(response.getOwner().getUserId(), image.getUser().getUserId());
         assertEquals(response.getImageUrl(), image.getImageUrl());
         assertFalse(response.isLike());
         assertEquals(response.getLikeCount(), image.getLikeList().size());

--- a/server/src/test/java/com/photoday/photoday/image/mapper/ImageMapperTest.java
+++ b/server/src/test/java/com/photoday/photoday/image/mapper/ImageMapperTest.java
@@ -61,9 +61,9 @@ class ImageMapperTest {
 
         // then
         assertEquals(pageResponse.getImageId(), image.getImageId());
-        assertEquals(pageResponse.isLike(), false);
+        assertFalse(pageResponse.isLike());
         assertEquals(pageResponse.getImageUrl(), image.getImageUrl());
-        assertEquals(pageResponse.isBookmark(), false);
+        assertFalse(pageResponse.isBookmark());
     }
 
     @Test

--- a/server/src/test/java/com/photoday/photoday/security/controller/AuthControllerTest.java
+++ b/server/src/test/java/com/photoday/photoday/security/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.photoday.photoday.helper.security.SecurityTestHelper;
 import com.photoday.photoday.security.redis.service.RedisService;
 import com.photoday.photoday.user.entity.User;
 import com.photoday.photoday.user.repository.UserRepository;
+import com.photoday.photoday.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,8 @@ class AuthControllerTest {
     private RedisService redisService;
     @MockBean
     private UserRepository userRepository;
+    @MockBean
+    private UserService userService;
 
     @Test
     @DisplayName("reissue: 정상 입력")

--- a/server/src/test/java/com/photoday/photoday/security/controller/LoginTest.java
+++ b/server/src/test/java/com/photoday/photoday/security/controller/LoginTest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.photoday.photoday.security.dto.LoginDto;
 import com.photoday.photoday.user.entity.User;
 import com.photoday.photoday.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,11 @@ public class LoginTest {
     private UserRepository userRepository;
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void clear() {
+        userRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("login: 정상 작동")

--- a/server/src/test/java/com/photoday/photoday/user/controller/UserControllerTest.java
+++ b/server/src/test/java/com/photoday/photoday/user/controller/UserControllerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -156,9 +155,7 @@ class UserControllerTest {
                 .andDo(document("update-user",
                         getRequestPreprocessor(),
                         getResponsePreprocessor(),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
+                        getRequestHeadersAccessToken(),
                         getResponsePartUpdateUser(),
                         getRequestPartFieldUpdateUser(),
                         getResponseFieldsUserDtoResponse()));
@@ -235,6 +232,7 @@ class UserControllerTest {
                 .andDo(document("get-user",
                         getRequestPreprocessor(),
                         getResponsePreprocessor(),
+                        getRequestHeadersAccessToken(),
                         getPathParametersUserId(),
                         getResponseFieldsUserDtoResponse()));
 
@@ -244,18 +242,22 @@ class UserControllerTest {
     @DisplayName("deleteUser: 정상 입력")
     void deleteUser() throws Exception {
         // given
+        Long userId = 1L;
         String accessToken = helper.getAccessToken("test@email.com", List.of("USER"));
 
-        doNothing().when(userService).deleteUser();
+        doNothing().when(userService).deleteUser(anyLong());
 
         // when
         ResultActions actions = mvc.perform(
-                delete("/api/users")
+                delete("/api/users/{userId}", userId)
                         .header("Authorization", "Bearer " + accessToken));
 
         // then
         actions
                 .andExpect(status().isNoContent())
-                .andDo(document("delete-User"));
+                .andDo(document("delete-User",
+                        getRequestPreprocessor(),
+                        getResponsePreprocessor(),
+                        getRequestHeadersAccessToken()));
     }
 }

--- a/server/src/test/java/com/photoday/photoday/user/mapper/UserMapperTest.java
+++ b/server/src/test/java/com/photoday/photoday/user/mapper/UserMapperTest.java
@@ -72,7 +72,7 @@ class UserMapperTest {
         follow.setFollowing(currentUser);
 
         // when
-        UserDto.Response response = userMapper.userToUserResponse(responseUser, currentUser.getUserId());
+        UserDto.Response response = userMapper.userToUserResponse(responseUser, currentUser);
 
         // then
         assertEquals(responseUser.getUserId(), response.getUserId());

--- a/server/src/test/java/com/photoday/photoday/user/service/UserServiceImplTest.java
+++ b/server/src/test/java/com/photoday/photoday/user/service/UserServiceImplTest.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static com.photoday.photoday.helper.snippets.RestDocsSnippets.getMockMultipartFile;
 import static org.junit.jupiter.api.Assertions.*;
@@ -52,7 +53,6 @@ class UserServiceImplTest {
         // given
         UserDto.Post post = new UserDto.Post("test@email.com", "123456a!");
         String defaultProfileImageUrl = "https://ifh.cc/g/zPrPfv.png";
-        given(authUserService.checkLogin()).willReturn(null);
 
         // when
         UserDto.Response userDtoResponse = userService.createUser(post);
@@ -125,7 +125,7 @@ class UserServiceImplTest {
 
         UserDto.Post post = new UserDto.Post("test@email.com", "123456a!");
         UserDto.Response ExpectedResponse = userService.createUser(post);
-        given(authUserService.getLoginUserId()).willReturn(loginUser.getUserId());
+        given(authUserService.getLoginUser()).willReturn(Optional.of(loginUser));
 
         // when
         UserDto.Response actualResponse = userService.getUser(ExpectedResponse.getUserId());
@@ -152,7 +152,7 @@ class UserServiceImplTest {
                 .password("123456a!")
                 .build();
         User loginUser = userRepository.save(user);
-        given(authUserService.getLoginUserId()).willReturn(loginUser.getUserId());
+        given(authUserService.getLoginUser()).willReturn(Optional.of(loginUser));
 
         UserDto.Update userUpdateDto = new UserDto.Update("edited!");
         MultipartFile multipartFile = getMockMultipartFile("multipartFile", "multipartFile");
@@ -176,7 +176,7 @@ class UserServiceImplTest {
                 .password("123456a!")
                 .build();
         User loginUser = userRepository.save(user);
-        given(authUserService.getLoginUserId()).willReturn(loginUser.getUserId());
+        given(authUserService.getLoginUser()).willReturn(Optional.of(loginUser));
 
         UserDto.Update userUpdateDto = new UserDto.Update("edited!");
 
@@ -198,7 +198,7 @@ class UserServiceImplTest {
                 .password("123456a!")
                 .build();
         User loginUser = userRepository.save(user);
-        given(authUserService.getLoginUserId()).willReturn(loginUser.getUserId());
+        given(authUserService.getLoginUser()).willReturn(Optional.of(loginUser));
 
         MultipartFile multipartFile = getMockMultipartFile("multipartFile", "multipartFile");
         given(s3Service.saveImage(any(MultipartFile.class))).willReturn("http://changedProfileImageUrl.jpg");

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -8,6 +8,10 @@ spring:
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    properties:
+      hibernate:
+        hibernate:
+          open-in-view: true
   output:
     ansi:
       enabled: always


### PR DESCRIPTION
## 📌 개요
- 이슈 번호: #203 

## ✨ 개발 내용
- userRepository에 자주 접근하는 것 리팩토링
- 수정 내용들 테스트에 적용

## 🔥 변경 로직(optional)
- UserMapper: userId, boolean 값 받던 것을 User객체로 한번에 받도록 수정
- AuthService: 유저 검증하고 `userId` 리턴하던 것을 `Optional<User>`를 리턴하도록 수정


### 📸 스크린샷(optional)

### 👓 고민사항(optional)

### 📩 전달사항(optional)
 - `Optional<User>`를 UserService외의 클래스에서 검증하고 있기때문에 나눠서 사용하도록 리팩토링 해야 합니다.

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)

