### PR TITLE
[Feature] 헤더 유저 프로필 리덕스 작업 

### DIFF
--- a/client/src/components/User/UserThumnailArea/UserThumnailArea.tsx
+++ b/client/src/components/User/UserThumnailArea/UserThumnailArea.tsx
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 import { useDispatch } from 'react-redux';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useContext } from 'react';
 import {
   S_UserThumnailArea,
   S_UserProfileIamge,
@@ -15,6 +15,7 @@ import { UserData } from '../../../store/userSlice';
 import { updateFile, deleteProfile } from '../../../api/User';
 import { setData } from '../../../store/userSlice';
 import { UploadImage } from '../../../pages/Upload/Upload';
+import { setUserProfile } from '../../../store/authSlice';
 
 export type User = {
   userData: UserData;
@@ -27,7 +28,6 @@ function UserThumnailArea({ userData, myPage }: User) {
   const [currentTap, setCurrentTap] = useState('follower');
   const [file, setFile] = useState<UploadImage | null>(null);
   const inputFileRef = useRef<HTMLInputElement>(null);
-
   useEffect(() => {
     uploadHandler();
   }, [file]);
@@ -88,6 +88,7 @@ function UserThumnailArea({ userData, myPage }: User) {
       const response = await updateFile(file.file);
       dispatch(setData(response));
       const { profileImageUrl } = response.data;
+      dispatch(setUserProfile(profileImageUrl));
       localStorage.setItem('userProfileImage', profileImageUrl);
     } catch (error) {
       if (error instanceof AxiosError) {

--- a/client/src/components/common/Footer/Footer.styles.tsx
+++ b/client/src/components/common/Footer/Footer.styles.tsx
@@ -1,20 +1,18 @@
 import styled from 'styled-components';
-import { ColFlex, RowFlex } from '../../../styles/GlobalStyles';
-import { Container } from '../../../styles/Layout';
+import { RowFlex } from '../../../styles/GlobalStyles';
 
 export const S_FooterContainerWrap = styled.footer`
   ${RowFlex}
   justify-content: center;
-`;
-
-export const S_FooterContainer = styled(Container)`
   position: fixed;
-  bottom: 0;
   justify-content: flex-end;
-  padding: 15px 0;
+
+  bottom: 0;
+  right: 0;
 `;
 
 export const S_FooterSpan = styled.span`
+  padding: 10px 50px;
   color: var(--color-primary-black);
   font-size: var(--font-size-sm);
 `;

--- a/client/src/components/common/Footer/Footer.tsx
+++ b/client/src/components/common/Footer/Footer.tsx
@@ -1,17 +1,11 @@
-import {
-  S_FooterContainer,
-  S_FooterContainerWrap,
-  S_FooterSpan,
-} from './Footer.styles';
+import { S_FooterContainerWrap, S_FooterSpan } from './Footer.styles';
 
 function Footer() {
   return (
     <S_FooterContainerWrap>
-      <S_FooterContainer>
-        <S_FooterSpan>
-          © 2023 MNK-photoday Team. All rights reserved.
-        </S_FooterSpan>
-      </S_FooterContainer>
+      <S_FooterSpan>
+        © 2023 MNK-photoday Team. All rights reserved.
+      </S_FooterSpan>
     </S_FooterContainerWrap>
   );
 }

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BiImageAdd } from 'react-icons/bi';
 import { RxTriangleDown } from 'react-icons/rx';
 import { Link } from 'react-router-dom';
@@ -28,8 +28,8 @@ function Header({ activeSearchBar }: HeaderProps) {
   const { isLoggedIn, userProfileImage } = useSelector(
     (state: RootState) => state.auth,
   );
-
   const [isActiveMenu, setIsActiveMenu] = useState(false);
+
   return (
     <S_HeaderWrap>
       <S_HeaderContainer>
@@ -51,10 +51,7 @@ function Header({ activeSearchBar }: HeaderProps) {
                 active={isActiveMenu}
                 onClick={() => setIsActiveMenu(!isActiveMenu)}
               >
-                <S_UserProfile
-                  src={userProfileImage}
-                  alt="유저 프로필 사진"
-                ></S_UserProfile>
+                <S_UserProfile alt="유저 프로필 사진" src={userProfileImage} />
                 <RxTriangleDown className="triangleDown-icon" />
                 {isActiveMenu && <HeaderModal />}
               </S_NavLinkIconBox>

--- a/client/src/components/common/ImageCard/MainImageCard.styles.tsx
+++ b/client/src/components/common/ImageCard/MainImageCard.styles.tsx
@@ -11,18 +11,18 @@ export const S_MainImageContentBox = styled.section`
   @media screen and (max-width: 1024px) {
     width: 100%;
     padding-left: 0px;
-    height: 100%;
+    height: 1040px;
     padding: 30px 0;
   }
 `;
 
 export const S_MainImageCardBox = styled.div`
-  width: 700px;
-  height: 100%;
+  width: 750px;
   display: grid;
   row-gap: 30px;
+  grid-auto-rows: 380px;
   @media screen and (max-width: 1024px) {
-    height: 800px;
+    grid-auto-rows: 450px;
   }
 `;
 

--- a/client/src/pages/Main/Main.styles.tsx
+++ b/client/src/pages/Main/Main.styles.tsx
@@ -10,7 +10,8 @@ export const S_MainContentBox = styled.div`
   width: 100%;
   justify-content: space-around;
   padding: 30px;
-  height: calc(100vh - 70px);
+  /*100vh - 헤더높이 - 푸터높이 */
+  height: calc(100vh - 70px - 20px);
 
   @media screen and (max-width: 1024px) {
     flex-wrap: wrap;

--- a/client/src/pages/Search/Search.tsx
+++ b/client/src/pages/Search/Search.tsx
@@ -33,7 +33,7 @@ function Search() {
             </S_SelectContentBox>
           </S_SearchMenuBox>
           <ImageCardList
-            width={477}
+            width={370}
             height={350}
             matrix="columns"
             filter={isSelect}

--- a/client/src/store/authSlice.ts
+++ b/client/src/store/authSlice.ts
@@ -5,6 +5,7 @@ type AuthState = {
   isLoggedIn: boolean;
   id: string | null;
   userProfileImage: string;
+  setUserProfile: string;
 };
 
 const userId = localStorage.getItem('id');
@@ -13,6 +14,7 @@ const initialState: AuthState = {
   isLoggedIn: checkAuth(),
   id: userId ? userId : null,
   userProfileImage: userProfileImage ? userProfileImage : '',
+  setUserProfile: userProfileImage ? userProfileImage : '',
 };
 
 const authSlice = createSlice({
@@ -41,8 +43,11 @@ const authSlice = createSlice({
     setLoggedIn: (state, action: PayloadAction<boolean>) => {
       state.isLoggedIn = action.payload;
     },
+    setUserProfile: (state, action) => {
+      state.userProfileImage = action.payload;
+    },
   },
 });
 
-export const { login, logout, setLoggedIn } = authSlice.actions;
+export const { login, logout, setLoggedIn, setUserProfile } = authSlice.actions;
 export default authSlice.reducer;

--- a/client/src/styles/Layout.tsx
+++ b/client/src/styles/Layout.tsx
@@ -11,6 +11,7 @@ export const ContainerWrap = styled.main`
 export const Container = styled.div`
   max-width: 1830px;
   width: 100%;
+  height: 100%;
   ${RowFlex}
   padding: 0 50px;
 `;


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #32 

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 헤더 유저 프로필 리덕스 작업 
- 이 외 스타일 수정 

### 변경 로직 
```js
  setUserProfile: (state, action) => {
      state.userProfileImage = action.payload;
    },
```
### 👓 고민사항(optional)
헤더의 유저프로필은 전역으로 관리되고 있는 userProfileImage 상태를 받아와 사용하고 있었지만,
 마이페이지에 유저프로필을 수정했을 때, 헤더 유저프로필은 새로고침을 해야만 수정한 이미지로 보이는 문제가 있었습니다. 

이 문제를 해결하기 위해 해당 리덕스 코드를 구현하신 아현님과 상의 후 setUserProfile  액션을 추가하고 마이 페이지에서 유저프로필을 변경한 순간 setUserProfile 액션이 실행하면서 변경된 ImageUrl 이 보내지도록 수정했습니다.


