### PR TITLE
[Fix] image url 길이 버그, 중복된 태그 처리 수정

### DIFF
--- a/server/src/main/java/com/photoday/photoday/image/entity/Image.java
+++ b/server/src/main/java/com/photoday/photoday/image/entity/Image.java
@@ -23,7 +23,7 @@ public class Image {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long imageId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String imageUrl;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
@@ -255,6 +255,7 @@ public class ImageServiceImpl implements ImageService {
     private List<ImageTag> tagListToImageTagList(List<Tag> tagList, Image image) {
         return tagList.stream()
                 .map(tagService::verifyTag)
+                .distinct()
                 .map(this::tagToImageTag)
                 .peek(imageTag -> imageTag.setImage(image))
                 .collect(Collectors.toList());

--- a/server/src/main/java/com/photoday/photoday/user/entity/User.java
+++ b/server/src/main/java/com/photoday/photoday/user/entity/User.java
@@ -34,7 +34,7 @@ public class User { //TODO 미사용 세터 정리
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     @Default
     private String profileImageUrl = "https://ifh.cc/g/zPrPfv.png";
 


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #282

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
data too long~ 에러를 해결하기 위해 image url column type 수정
mysql 컬럼 타입 확인 및 버그 수정 확인 완료. 

## 🔥 변경 로직(optional)
<!-- 변경된 로직이 있다면 적어주세요. -->
이미지 업로드시 중복된 태그 처리 로직 추가 

### 📸 스크린샷(optional)
<!-- 관련 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="1421" alt="스크린샷 2023-03-29 오후 12 01 32" src="https://user-images.githubusercontent.com/108881135/228416649-88588a06-ed18-419d-aa1f-cc024a644c51.png">


### 👓 고민사항(optional)

### 📩 전달사항(optional)

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)
<!-- 참고할 사항이 있다면 적어주세요 -->
