### PR TITLE
[Feat/resize] 이미지 리사이징 기능 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -55,6 +55,10 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	implementation 'com.github.downgoon:marvin:1.5.5'
+	implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
+	implementation 'org.springframework:spring-test'
 }
 
 ext {

--- a/server/src/main/java/com/photoday/photoday/image/dto/ImageDto.java
+++ b/server/src/main/java/com/photoday/photoday/image/dto/ImageDto.java
@@ -43,7 +43,7 @@ public class ImageDto {
     @Getter
     public static class PageResponse {
         private Long imageId;
-        private String imageUrl;
+        private String thumbnailUrl;
         private boolean like;
         private boolean bookmark;
     }

--- a/server/src/main/java/com/photoday/photoday/image/entity/Image.java
+++ b/server/src/main/java/com/photoday/photoday/image/entity/Image.java
@@ -26,6 +26,9 @@ public class Image {
     @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String imageUrl;
 
+    @Column(columnDefinition = "LONGTEXT")
+    private String resizedUrl;
+
     @Column(nullable = false)
     private int viewCount;
 

--- a/server/src/main/java/com/photoday/photoday/image/entity/Image.java
+++ b/server/src/main/java/com/photoday/photoday/image/entity/Image.java
@@ -27,7 +27,7 @@ public class Image {
     private String imageUrl;
 
     @Column(columnDefinition = "LONGTEXT")
-    private String resizedUrl;
+    private String thumbnailUrl;
 
     @Column(nullable = false)
     private int viewCount;

--- a/server/src/main/java/com/photoday/photoday/image/mapper/ImageMapper.java
+++ b/server/src/main/java/com/photoday/photoday/image/mapper/ImageMapper.java
@@ -20,7 +20,7 @@ public class ImageMapper {
     public ImageDto.PageResponse imageToPageResponse(Image image) {
         return ImageDto.PageResponse.builder()
                 .imageId(image.getImageId())
-                .imageUrl(image.getImageUrl())
+                .thumbnailUrl(image.getThumbnailUrl()==null? image.getImageUrl(): image.getThumbnailUrl())
                 .like(hasLiked(image))
                 .bookmark(hasBookmarked(image))
                 .build();

--- a/server/src/main/java/com/photoday/photoday/image/service/S3Service.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/S3Service.java
@@ -9,6 +9,8 @@ import java.security.NoSuchAlgorithmException;
 public interface S3Service {
     String saveImage(MultipartFile multipartFile) throws IOException, NoSuchAlgorithmException;
 
+    String resizeImage(MultipartFile multipartFile, int targetWidth) throws IOException;
+
     String getMd5Hash(MultipartFile file) throws IOException, NoSuchAlgorithmException;
 
     byte[] downloadImage(String imagePath) throws IOException;

--- a/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
+++ b/server/src/main/java/com/photoday/photoday/image/service/impl/ImageServiceImpl.java
@@ -68,7 +68,9 @@ public class ImageServiceImpl implements ImageService {
 //        Long userId = authUserService.getLoginUserId();
 
         String imageUrl = s3Service.saveImage(multipartFile);
-        Image image = makeImage(imageUrl, user);
+        String thumbnailUrl = s3Service.resizeImage(multipartFile, 800);
+
+        Image image = makeImage(imageUrl, thumbnailUrl,user);
         image.setImageHashValue(imageHashValue);
 
         List<Tag> tagList = tagMapper.dtoToTag(post);
@@ -104,7 +106,7 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public void deleteImage(long imageId) {
+    public void deleteImage(long imageId) { //이미지 삭제하면 DB뿐만 아니라 s3에서도 삭제해야할 듯.
         Image image = findVerifiedImage(imageId);
 //        Long userId = authUserService.getLoginUserId();
         User user = authUserService.getLoginUser().orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -242,12 +244,13 @@ public class ImageServiceImpl implements ImageService {
         return optionalImage.orElseThrow(() -> new CustomException(IMAGE_NOT_FOUND));
     }
 
-    private Image makeImage(String imageUrl, User user) {
+    private Image makeImage(String imageUrl, String thumbnailUrl, User user) {
 //        User user = userService.findVerifiedUser(userId);
 
         Image image = new Image();
         image.setImageUrl(imageUrl);
         image.setUser(user);
+        image.setThumbnailUrl(thumbnailUrl);
 
         return image;
     }


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #308 

## ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 가로 길이가 800이 넘는 사진에 한하여 썸네일을 함께 저장하도록 하였음. 
- 여러 장의 사진을 반환하여 띄우는 pageResponse의 경우(메인화면, 태그검색), 작은 용량의 이미지 url을 반환하도록 하였음.  

## 🔥 변경 로직(optional)
<!-- 변경된 로직이 있다면 적어주세요. -->

### 📸 스크린샷(optional)
<!-- 관련 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="1106" alt="스크린샷 2023-05-04 오후 9 42 49" src="https://user-images.githubusercontent.com/108881135/236207717-40084ee0-b910-4699-99cf-655c9b7542e9.png">
- s3에 업로드된 화면입니다. 썸네일Url의 경우, 기존 파일명 앞에 "s_"가 붙습니다.  

### 👓 고민사항(optional)
- 로직 보다보니까 이미지 삭제할 때, DB에서 삭제하는 것뿐만 아니라 s3에서도 삭제해야할 필요성을 느꼈습니다. 
괜찮으시다면 이 부분도 수정해볼게요. 
- 일단은 be-dev에만 merge 후 배포해서, 프론트 분들이랑 실험해보면 좋을 것 같아요. 

### 📩 전달사항(optional)
일단 포스트맨으로 실험은 해봤는데, 테스트 코드도 작성할게요. 

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)
<!-- 참고할 사항이 있다면 적어주세요 -->
